### PR TITLE
issues/15 explicit matching group for version extraction needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A configuration has the following parameters:
 - *autoverBranchConfigs*: The branch configurations
    - *nameRegex*: This is used to determine the branches that should use this configuration
    - *stopOn*: the stop on setting to be used by branches that match the above pattern possible values
-      - *ON_FIRST*: It will use the first annotation that it will find (regardles of the type)
+      - *ON_FIRST*: It will use the first annotation that it will find (regardless of the type)
       - *ON_FIRST_ANN*: It will use the first annotated branch that it will find
       - *ON_FIRST_LIGHT*: It will use the first light branch that it will find
 The branch name is checked against the configured branches in the order from the configuration file and it stops on the first that matches.
@@ -29,7 +29,7 @@ The plugin will look to the git history and "walk back" from current commit unti
 
 # Default configuration
 The plugin has the following default configuration.
-- *versionTagRegex* - [0-9]+\\.[0-9]+\\.([0-9]+)(-SNAPSHOT)?
+- *versionTagRegex* - ([0-9]+\\.[0-9]+\\.([0-9]+)(-SNAPSHOT)?)
 - *includeGroupIds* - empty (all groups will be considered)
 - *autoverBranchConfigs*
   - *master*                        - ON_FIRST_LIGHT
@@ -45,4 +45,4 @@ This custom configuration file should have the name *git.autover.conf.xml* and b
 
 # How to disable it
 The plugin execution can be disabled using *-Dautover.disable=true*. This way the version specified in the pom file will be used.
-Also one could disable only the pom changes using *-Dautover.disable.pom.change=true*.
+Also, one could disable only the pom changes using *-Dautover.disable.pom.change=true*.

--- a/src/test/java/de/palsoftware/tools/maven/git/autover/ConfigHelperTest.java
+++ b/src/test/java/de/palsoftware/tools/maven/git/autover/ConfigHelperTest.java
@@ -95,8 +95,8 @@ public class ConfigHelperTest {
     }
 
     private void assertSameBranchConfig(final AutoverBranchConfig branchConfig, final AutoverBranchConfigDecorator foundBranchConfig) {
-        Assert.assertTrue("ConfigHelper -> getBranchConfig problem!", branchConfig.getNameRegex().equals(foundBranchConfig.getNameRegex()));
-        Assert.assertTrue("ConfigHelper -> getBranchConfig problem!", branchConfig.getStopOn().equals(foundBranchConfig.getStopOn()));
+		Assert.assertEquals("ConfigHelper -> getBranchConfig problem!", branchConfig.getNameRegex(), foundBranchConfig.getNameRegex());
+		Assert.assertEquals("ConfigHelper -> getBranchConfig problem!", branchConfig.getStopOn(), foundBranchConfig.getStopOn());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        F              F         T
         gitAnalysisResult.setOnTag(true);
@@ -121,7 +121,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        F              T         F
         gitAnalysisResult.setOnTag(true);
@@ -130,7 +130,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        F              T         T
         gitAnalysisResult.setOnTag(true);
@@ -139,7 +139,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        T              F         F
         gitAnalysisResult.setOnTag(true);
@@ -148,7 +148,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        T              F         T
         gitAnalysisResult.setOnTag(true);
@@ -157,7 +157,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        T              T         F
         gitAnalysisResult.setOnTag(true);
@@ -166,7 +166,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //T        T              T         T
         gitAnalysisResult.setOnTag(true);
@@ -175,7 +175,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        F              F         F
         gitAnalysisResult.setOnTag(false);
@@ -184,7 +184,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        F              F         T
         gitAnalysisResult.setOnTag(false);
@@ -193,7 +193,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-LIB_111".equals(configHelper.calculateVer(gitAnalysisResult)));
+        Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-LIB_111", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        F              T         F
         gitAnalysisResult.setOnTag(false);
@@ -202,7 +202,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.1-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+        Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.1-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        F              T         T
         gitAnalysisResult.setOnTag(false);
@@ -211,7 +211,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.1-LIB_111-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.1-LIB_111-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        T              F         F
         gitAnalysisResult.setOnTag(false);
@@ -220,7 +220,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        T              F         T
         gitAnalysisResult.setOnTag(false);
@@ -229,7 +229,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(false);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.0-LIB_111-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0-LIB_111-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        T              T         F
         gitAnalysisResult.setOnTag(false);
@@ -238,7 +238,7 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("release/1.1.x");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.1-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.1-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
         //on tag | tag snapshot | ann tag | bq
         //F        T              T         T
         gitAnalysisResult.setOnTag(false);
@@ -247,7 +247,30 @@ public class ConfigHelperTest {
         gitAnalysisResult.setAnnotatedTag(true);
         gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
         gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
-        Assert.assertTrue("ConfigHelper -> calculateVer problem!", "1.0.1-LIB_111-SNAPSHOT".equals(configHelper.calculateVer(gitAnalysisResult)));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.1-LIB_111-SNAPSHOT", configHelper.calculateVer(gitAnalysisResult));
+
+        //on tag | tag snapshot | ann tag | bq
+        //T        F              T         T
+        autoverConfig.setVersionTagRegex("(?:release[\\/])?([0-9]+\\.[0-9]+\\.([0-9]+)(-SNAPSHOT)?)");
+        ConfigHelper newConfigHelper = new ConfigHelper(new AutoverConfigDecorator(autoverConfig));
+        gitAnalysisResult.setOnTag(true);
+        tagName = "release/1.0.0";
+        gitAnalysisResult.setTagName(tagName);
+        gitAnalysisResult.setAnnotatedTag(true);
+        gitAnalysisResult.setBranchName("feature/LIB-111-test-junit");
+        gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_FEATURE_CONFIG));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.0", newConfigHelper.calculateVer(gitAnalysisResult));
+        //on tag | tag snapshot | ann tag | bq
+        //T        F              T         T
+        autoverConfig.setVersionTagRegex("(?:release[\\/])?([0-9]+\\.[0-9]+\\.([0-9]+)(-SNAPSHOT)?)");
+        newConfigHelper = new ConfigHelper(new AutoverConfigDecorator(autoverConfig));
+        gitAnalysisResult.setOnTag(false);
+        tagName = "release/1.0.0";
+        gitAnalysisResult.setTagName(tagName);
+        gitAnalysisResult.setAnnotatedTag(true);
+        gitAnalysisResult.setBranchName("release/1.1.x");
+        gitAnalysisResult.setBranchConfig(new AutoverBranchConfigDecorator(ConfigHelper.DEFAULT_RELEASE_CONFIG));
+		Assert.assertEquals("ConfigHelper -> calculateVer problem!", "1.0.1-SNAPSHOT", newConfigHelper.calculateVer(gitAnalysisResult));
     }
 
     @Test


### PR DESCRIPTION
Hi @edipal ,

we'd like to have some prefixes, as `release/` on the version tag.
e.g. `release/0.23.3` instead of `0.23.3`
is it possible to extend the regex so that it has non-matching-groups for the prefix, e.g. `(?:release[\/])?[0-9]+\.[0-9]+\.([0-9]+)(-SNAPSHOT)?`

or maybe better to have matching `group(1)` as the version string - and having `group(2)` as bugfix-version.

`(?:release[\/])?([0-9]+\.[0-9]+\.([0-9]+)(-SNAPSHOT)?)`

<img width="1411" height="642" alt="Image" src="https://github.com/user-attachments/assets/e494b39e-7e3e-4776-9cbf-c14c2d8d1f54" />

Thx a lot